### PR TITLE
Eliminate PHP throws notices

### DIFF
--- a/library/PhpGedcom/Parser/Indi/Name.php
+++ b/library/PhpGedcom/Parser/Indi/Name.php
@@ -51,6 +51,10 @@ class Name extends \PhpGedcom\Parser\Component
                 break;
             }
 
+            if (!isset($record[2])) {
+                $record[2] = '';
+            }
+
             switch ($recordType) {
                 case 'NPFX':
                     $name->setNpfx(trim($record[2]));


### PR DESCRIPTION
Sometimes a gedcom file might have missing data in the event of the researcher only knowing a first name or last name. In these cases a gedcom file might end up with empty `SURN` or `GIVN` records for an individual.

When your code finds such records there is no `$record[2]` in the record array. I just added a quick and dirty fix to add an empty string at index 2 in such cases.