### PR TITLE
Fix attr event overwriting

### DIFF
--- a/library/PhpGedcom/Record/Indi.php
+++ b/library/PhpGedcom/Record/Indi.php
@@ -216,7 +216,13 @@ class Indi extends Record implements Noteable, Objectable, Sourceable
      */
     public function addAttr($attr = [])
     {
-        $this->attr[$attr->getType()] = $attr;
+        $attrName = $attr->getType();
+
+        if (!array_key_exists($attrName, $this->attr)) {
+            $this->attr[$attrName] = [];
+        }
+
+        $this->attr[$attrName][] = $attr;
         return $this;
     }
 
@@ -243,8 +249,14 @@ class Indi extends Record implements Noteable, Objectable, Sourceable
      */
     public function addEven($even = [])
     {
-        $this->even[$even->getType()] = $even;
-        return $this;
+        $evenName = $even->getType();
+
+        if (!array_key_exists($evenName, $this->even)) {
+            $this->even[$evenName] = [];
+        }
+
+        $this->even[$evenName][] = $even;
+        return $thi
     }
 
   /**

--- a/library/PhpGedcom/Record/Indi.php
+++ b/library/PhpGedcom/Record/Indi.php
@@ -256,7 +256,7 @@ class Indi extends Record implements Noteable, Objectable, Sourceable
         }
 
         $this->even[$evenName][] = $even;
-        return $thi
+        return $this;
     }
 
   /**

--- a/library/PhpGedcom/Record/Indi.php
+++ b/library/PhpGedcom/Record/Indi.php
@@ -227,7 +227,7 @@ class Indi extends Record implements Noteable, Objectable, Sourceable
     }
 
   /**
-   * @return Indi\Attr[]
+   * @return array
    */
   public function getAllAttr()
   {


### PR DESCRIPTION
I found that when parsing individuals that have more than one event or attr tags in the GED file, the data was being overwritten on the resulting Individual Record objects.

This change fixes that issue in the following way:

1. First checks to see if an event or attr exists on the individual
2. If it does not it will create a key for it in the attr or even array and init an empty array as the value
3. It will then push the incoming even or attr data into the array under the key.

Now when you call `getAllAttr()` or `getAllEven()` on an individual, you'll get multi-dimensional array with each key being an array of the various events or attributes. Calling `getAttr($attr)` or `getEven($even)` will simply return the array of attrs or events of that type.

Cheers,

J