### PR TITLE
Add `_attr` property to EVEN Record to capture data from incoming record

### DIFF
--- a/library/PhpGedcom/Parser/Indi/Attr.php
+++ b/library/PhpGedcom/Parser/Indi/Attr.php
@@ -40,7 +40,6 @@ abstract class Attr extends \PhpGedcom\Parser\Component
            return null;
         }
 
-
         if (isset($record[2])) {
             $attr->setAttr(trim($record[2]));
         }

--- a/library/PhpGedcom/Parser/Indi/Even.php
+++ b/library/PhpGedcom/Parser/Indi/Even.php
@@ -49,6 +49,11 @@ class Even extends \PhpGedcom\Parser\Component
             $even->setType(trim($record[1]));
         }
 
+        // ensures we capture any data following the EVEN type
+        if (isset($record[2]) && !empty($record[2])) {
+            $even->setAttr(trim($record[2]));
+        }
+
         $parser->forward();
 
         while (!$parser->eof()) {

--- a/library/PhpGedcom/Record/Indi/Even.php
+++ b/library/PhpGedcom/Record/Indi/Even.php
@@ -30,6 +30,11 @@ class Even extends Record implements Record\Objectable, Record\Sourceable, Recor
     /**
      * @var string
      */
+    protected $_attr;
+
+    /**
+     * @var string
+     */
     protected $date;
 
     /**


### PR DESCRIPTION
I'm working with a GEDCOM file generated by [Legacy](https://legacyfamilytree.com/) and it seems to add data after `EVEN` keywords. This suggested fix enables the capturing of such data. Here is a sample from my GEDCOM so you can see:

```
0 @I29@ INDI
1 NAME John Michael /Harrison/
2 GIVN John Michael
2 SURN Harrison
1 SEX M
1 BIRT
2 DATE 18 May 1868
2 PLAC 28 Walmer Street, Poolstock, Wigan, England
1 DEAT
2 DATE 12 Nov 1937
2 PLAC Toronto, Ontario
1 BURI
2 PLAC St James Cemetery, Toronto
1 _TAG
1 _TAG2
1 EVEN John's mother registered his birth incorrectly
2 TYPE Birth Registration
2 DATE 11 Jun 1868
2 PLAC Wigan, Lancashire
2 NOTE Although he was named John Michael Harrison by his parents
3 CONC , his mother registered his birth as John Harrison.  He w
3 CONC as not aware of this error until he applied for a passpor
3 CONC t circa 1925.
3 CONT
3 CONT The family was living at 20 Walmer Street, Poolstock, Wiga
3 CONC n suggesting that Harold's father had not yet purchased th
3 CONC e Honeysuckle Inn.
1 CENS John recorded living at the Honeysuckle Inn with his parents and aunts Annie and Ellen Burton
2 DATE 5 Apr 1891
2 PLAC Honeysuckle Inn, Poolstock, Wigan
2 NOTE John, age 4, was living at the Honeysuckle with his fathe
3 CONC r and mother and his mother's two sisters Annie and Ellen B
3 CONC urton, both single and evidently employed at the inn.
1 RESI Per 1891 Census
2 DATE 5 Apr 1891
2 PLAC Honeysuckle Inn, Poolstock, Wigan
1 _UID 68D2F898A6654CECB632036BB9CCCA0ABC96
1 CHAN
2 DATE 20 Jan 2008
3 TIME 17:42
1 FAMS @F38@
1 FAMC @F9@
1 NOTE @NI29@
1 NOTE @HI29@
```