### PR TITLE
Repaired items broken in php 7.3

### DIFF
--- a/library/PhpGedcom/Parser.php
+++ b/library/PhpGedcom/Parser.php
@@ -213,7 +213,7 @@ class Parser
 
         $line = trim($this->_line);
 
-        $this->_lineRecord = explode(' ', $line, $pieces);
+        $this->_lineRecord = array_pad(explode(' ', $line, $pieces), 3, '');
         $this->_linePieces = $pieces;
 
         return $this->_lineRecord;

--- a/library/PhpGedcom/Record/Repo.php
+++ b/library/PhpGedcom/Record/Repo.php
@@ -66,7 +66,7 @@ class Repo extends Record implements Noteable
      * @param Phon $phon
      * @return Repo
      */
-    public function addPhon($phon = new Phon)
+    public function addPhon($phon)
     {
         $this->phon[] = $phon;
         return $this;
@@ -84,7 +84,7 @@ class Repo extends Record implements Noteable
      * @param Refn $refn
      * @return Repo
      */
-    public function addRefn($refn = new Refn)
+    public function addRefn($refn)
     {
         $this->refn[] = $refn;
         return $this;
@@ -102,7 +102,7 @@ class Repo extends Record implements Noteable
      * @param NoteRef $note
      * @return Repo
      */
-    public function addNote($note =  new NoteRef)
+    public function addNote($note = array())
     {
         $this->note[] = $note;
         return $this;
@@ -156,7 +156,7 @@ class Repo extends Record implements Noteable
      * @param \PhpGedcom\Record\Addr $addr
      * @return Repo
      */
-    public function setAddr($addr = new Addr)
+    public function setAddr($addr)
     {
         $this->addr = $addr;
         return $this;


### PR DESCRIPTION
- Padded _lineRecord to ensure it meets the expectation of 3 values, even if unset.
- Changed Record/Repo to use acceptable 7.3 arguments